### PR TITLE
Adding CI support for cypress, deleting random file that appeared from nowhere

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run jest tests
         run: npm test
       - name: Run e2e tests
-        run: npm run e2e
+        run: npm run e2e-record
       - name: Upload unit test coverage
         if: success()
         uses: codecov/codecov-action@v1

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -36,6 +36,8 @@ jobs:
         run: npm run lint
       - name: Run jest tests
         run: npm test
+      - name: Run e2e tests
+        run: npm run e2e
       - name: Upload unit test coverage
         if: success()
         uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "lint": "eslint --ext=tsx --ext=js --ext=jsx --fix ./src",
     "cy:open": "cypress open",
     "cy:run": "cypress run",
-    "cy:run-record": "cypress run --record --key 138928d3-61ed-4b27-9f40-fbed614d3596"
+    "cy:run-record": "cypress run --record --key 138928d3-61ed-4b27-9f40-fbed614d3596",
+    "e2e": "start-server-and-test start http://localhost:3000 cy:run",
+    "e2e-record": "start-server-and-test start http://localhost:3000 cy:run-record"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
…m nowhere

Installing start-server-and-test, which is used for testing headless browser. This starts the server on localhost:3000 on the CI and cypress can run the necessary tests on it.

Removing { file. Not sure where this came from.